### PR TITLE
Fixed memory allocation bugs: no space for biases

### DIFF
--- a/src/glove.c
+++ b/src/glove.c
@@ -64,12 +64,12 @@ void initialize_parameters() {
 	vector_size++; // Temporarily increment to allocate space for bias
     
 	/* Allocate space for word vectors and context word vectors, and correspodning gradsq */
-	a = posix_memalign((void **)&W, 128, 2 * vocab_size * vector_size * sizeof(real)); // Might perform better than malloc
+	a = posix_memalign((void **)&W, 128, 2 * vocab_size * (vector_size + 1) * sizeof(real)); // Might perform better than malloc
     if (W == NULL) {
         fprintf(stderr, "Error allocating memory for W\n");
         exit(1);
     }
-    a = posix_memalign((void **)&gradsq, 128, 2 * vocab_size * vector_size * sizeof(real)); // Might perform better than malloc
+    a = posix_memalign((void **)&gradsq, 128, 2 * vocab_size * (vector_size + 1) * sizeof(real)); // Might perform better than malloc
 	if (gradsq == NULL) {
         fprintf(stderr, "Error allocating memory for gradsq\n");
         exit(1);


### PR DESCRIPTION
Memory was allocated without space for biases. As the result of this some gradients were overwritten by weights, and some costs were overwritten by gradients.

You can see below that word vector positions inside W are calculated with additional space for bias (`+ 1`), for example:
```C
/* Get location of words in W & gradsq */
l1 = (cr.word1 - 1LL) * (vector_size + 1); // cr word indices start at 1
l2 = ((cr.word2 - 1LL) + vocab_size) * (vector_size + 1); // shift by vocab_size to get separate vectors for context words
```
 Thus the memory allocation must also use additional space.

With this fix applied the algorithm tends to perform slightly better on provided analogy tests.