### PR TITLE
fixed shuffle call to obey array boundaries

### DIFF
--- a/src/shuffle.c
+++ b/src/shuffle.c
@@ -164,7 +164,7 @@ int shuffle_by_chunks() {
         if(feof(fin)) break;
         i++;
     }
-    shuffle(array, i-1); //Last chunk may be smaller than array_size
+    shuffle(array, i-2); //Last chunk may be smaller than array_size
     write_chunk(array,i,fid);
     l += i;
     if(verbose > 1) fprintf(stderr, "\033[22Gprocessed %ld lines.\n", l);


### PR DESCRIPTION
shuffle accesses array at index n+1, so the passed n should be i-2 like a few lines above