### PR TITLE
Length check in write_chunk().

### DIFF
--- a/src/cooccur.c
+++ b/src/cooccur.c
@@ -140,6 +140,8 @@ int get_word(char *word, FILE *fin) {
 
 /* Write sorted chunk of cooccurrence records to file, accumulating duplicate entries */
 int write_chunk(CREC *cr, long long length, FILE *fout) {
+    if (length == 0) return 0;
+
     long long a = 0;
     CREC old = cr[a];
     


### PR DESCRIPTION
_cooccur_ introduces all-0 record(s) if one of the chunks it tries to write is empty; this can happen if the vocabulary is small (17 in my case). This PR fixes that.

Note that I haven't checked if a small vocabulary introduces other errors.