### PR TITLE
Saving checkpoint on SIGUSR1 signal

### DIFF
--- a/src/glove.c
+++ b/src/glove.c
@@ -383,7 +383,7 @@ int start_sig_handler_thread(pthread_t *sig_handler_pt) {
   sigset_t sig_mask;
   sigemptyset(&sig_mask);
   sigaddset(&sig_mask, SIGUSR1);
-  sigprocmask(SIG_BLOCK, &sig_mask, NULL);
+  pthread_sigmask(SIG_BLOCK, &sig_mask, NULL);
 
   return pthread_create(sig_handler_pt, NULL, sig_handler_thread, NULL);
 }


### PR DESCRIPTION
This modification allows to request saving a checkpoint at the end of current iteration by sending SIGUSR1 signal to glove process: `kill -s SIGUSR1 <PID>`.

Implementation starts a dedicated signal handling thread, which waits for SIGUSR1 signal using `sigwait(...)` function.