### PR TITLE
Detect overflow earlier. 

### DIFF
--- a/src/cooccur.c
+++ b/src/cooccur.c
@@ -144,7 +144,7 @@ int write_chunk(CREC *cr, long long length, FILE *fout) {
 
     long long a = 0;
     CREC old = cr[a];
-    
+
     for (a = 1; a < length; a++) {
         if (cr[a].word1 == old.word1 && cr[a].word2 == old.word2) {
             old.val += cr[a].val;
@@ -162,7 +162,7 @@ int compare_crec(const void *a, const void *b) {
     int c;
     if ( (c = ((CREC *) a)->word1 - ((CREC *) b)->word1) != 0) return c;
     else return (((CREC *) a)->word2 - ((CREC *) b)->word2);
-    
+
 }
 
 /* Check if two cooccurrence records are for the same two words */
@@ -233,7 +233,7 @@ int merge_files(int num) {
     pq = malloc(sizeof(CRECID) * num);
     fout = stdout;
     if (verbose > 1) fprintf(stderr, "Merging cooccurrence files: processed 0 lines.");
-    
+
     /* Open all files and add first entry of each to priority queue */
     for (i = 0; i < num; i++) {
         sprintf(filename,"%s_%04d.bin",file_head,i);
@@ -243,7 +243,7 @@ int merge_files(int num) {
         new.id = i;
         insert(pq,new,i+1);
     }
-    
+
     /* Pop top node, save it in old to see if the next entry is a duplicate */
     size = num;
     old = pq[0];
@@ -255,7 +255,7 @@ int merge_files(int num) {
         new.id = i;
         insert(pq, new, size);
     }
-    
+
     /* Repeatedly pop top node and fill priority queue until files have reached EOF */
     while (size > 0) {
         counter += merge_write(pq[0], &old, fout); // Only count the lines written to file, not duplicates
@@ -289,7 +289,7 @@ int get_cooccurrence() {
     HASHREC *htmp, **vocab_hash = inithashtable();
     CREC *cr = malloc(sizeof(CREC) * (overflow_length + 1));
     history = malloc(sizeof(long long) * window_size);
-    
+
     fprintf(stderr, "COUNTING COOCCURRENCES\n");
     if (verbose > 0) {
         fprintf(stderr, "window size: %d\n", window_size);
@@ -307,7 +307,7 @@ int get_cooccurrence() {
     vocab_size = j;
     j = 0;
     if (verbose > 1) fprintf(stderr, "loaded %lld words.\nBuilding lookup table...", vocab_size);
-    
+
     /* Build auxiliary lookup table used to index into bigram_table */
     lookup = (long long *)calloc( vocab_size + 1, sizeof(long long) );
     if (lookup == NULL) {
@@ -320,23 +320,23 @@ int get_cooccurrence() {
         else lookup[a] = lookup[a-1] + vocab_size;
     }
     if (verbose > 1) fprintf(stderr, "table contains %lld elements.\n",lookup[a-1]);
-    
+
     /* Allocate memory for full array which will store all cooccurrence counts for words whose product of frequency ranks is less than max_product */
     bigram_table = (real *)calloc( lookup[a-1] , sizeof(real) );
     if (bigram_table == NULL) {
         fprintf(stderr, "Couldn't allocate memory!");
         return 1;
     }
-    
+
     fid = stdin;
     sprintf(format,"%%%ds",MAX_STRING_LENGTH);
     sprintf(filename,"%s_%04d.bin",file_head, fidcounter);
     foverflow = fopen(filename,"w");
     if (verbose > 1) fprintf(stderr,"Processing token: 0");
-    
+
     /* For each token in input stream, calculate a weighted cooccurrence sum within window_size */
     while (1) {
-        if (ind >= overflow_length - window_size) { // If overflow buffer is (almost) full, sort it and write it to temporary file
+        if (ind >= overflow_length - 2*window_size) { // If overflow buffer is (almost) full, sort it and write it to temporary file
             qsort(cr, ind, sizeof(CREC), compare_crec);
             write_chunk(cr,ind,foverflow);
             fclose(foverflow);
@@ -375,13 +375,13 @@ int get_cooccurrence() {
         history[j % window_size] = w2; // Target word is stored in circular buffer to become context word in the future
         j++;
     }
-    
+
     /* Write out temp buffer for the final time (it may not be full) */
     if (verbose > 1) fprintf(stderr,"\033[0GProcessed %lld tokens.\n",counter);
     qsort(cr, ind, sizeof(CREC), compare_crec);
     write_chunk(cr,ind,foverflow);
     sprintf(filename,"%s_0000.bin",file_head);
-    
+
     /* Write out full bigram_table, skipping zeros */
     if (verbose > 1) fprintf(stderr, "Writing cooccurrences to disk");
     fid = fopen(filename,"w");
@@ -396,7 +396,7 @@ int get_cooccurrence() {
             }
         }
     }
-    
+
     if (verbose > 1) fprintf(stderr,"%d files in total.\n",fidcounter + 1);
     fclose(fid);
     fclose(foverflow);
@@ -426,7 +426,7 @@ int main(int argc, char **argv) {
     real rlimit, n = 1e5;
     vocab_file = malloc(sizeof(char) * MAX_STRING_LENGTH);
     file_head = malloc(sizeof(char) * MAX_STRING_LENGTH);
-    
+
     if (argc == 1) {
         printf("Tool to calculate word-word cooccurrence statistics\n");
         printf("Author: Jeffrey Pennington (jpennin@stanford.edu)\n\n");
@@ -461,18 +461,17 @@ int main(int argc, char **argv) {
     if ((i = find_arg((char *)"-overflow-file", argc, argv)) > 0) strcpy(file_head, argv[i + 1]);
     else strcpy(file_head, (char *)"overflow");
     if ((i = find_arg((char *)"-memory", argc, argv)) > 0) memory_limit = atof(argv[i + 1]);
-    
+
     /* The memory_limit determines a limit on the number of elements in bigram_table and the overflow buffer */
     /* Estimate the maximum value that max_product can take so that this limit is still satisfied */
     rlimit = 0.85 * (real)memory_limit * 1073741824/(sizeof(CREC));
     while (fabs(rlimit - n * (log(n) + 0.1544313298)) > 1e-3) n = rlimit / (log(n) + 0.1544313298);
     max_product = (long long) n;
     overflow_length = (long long) rlimit/6; // 0.85 + 1/6 ~= 1
-    
+
     /* Override estimates by specifying limits explicitly on the command line */
     if ((i = find_arg((char *)"-max-product", argc, argv)) > 0) max_product = atoll(argv[i + 1]);
     if ((i = find_arg((char *)"-overflow-length", argc, argv)) > 0) overflow_length = atoll(argv[i + 1]);
-    
+
     return get_cooccurrence();
 }
-

--- a/src/glove.c
+++ b/src/glove.c
@@ -63,23 +63,24 @@ int scmp( char *s1, char *s2 ) {
 }
 
 void initialize_parameters() {
-	long long a, b;
-	vector_size++; // Temporarily increment to allocate space for bias
-    
-	/* Allocate space for word vectors and context word vectors, and correspodning gradsq */
-	a = posix_memalign((void **)&W, 128, 2 * vocab_size * (vector_size + 1) * sizeof(real)); // Might perform better than malloc
-    if (W == NULL) {
-        fprintf(stderr, "Error allocating memory for W\n");
-        exit(1);
-    }
-    a = posix_memalign((void **)&gradsq, 128, 2 * vocab_size * (vector_size + 1) * sizeof(real)); // Might perform better than malloc
-	if (gradsq == NULL) {
-        fprintf(stderr, "Error allocating memory for gradsq\n");
-        exit(1);
-    }
-	for (b = 0; b < vector_size; b++) for (a = 0; a < 2 * vocab_size; a++) W[a * vector_size + b] = (rand() / (real)RAND_MAX - 0.5) / vector_size;
-	for (b = 0; b < vector_size; b++) for (a = 0; a < 2 * vocab_size; a++) gradsq[a * vector_size + b] = 1.0; // So initial value of eta is equal to initial learning rate
-	vector_size--;
+  long long a, b;
+
+  /* Allocate space for word vectors and context word vectors, and correspodning gradsq */
+  long long w_size = (2 * vocab_size * (vector_size+2) + vector_size );
+  a = posix_memalign((void **)&W, 128, w_size * sizeof(real)); // Might perform better than malloc
+  if (W == NULL) {
+    fprintf(stderr, "Error allocating memory for W\n");
+    exit(1);
+  }
+  a = posix_memalign((void **)&gradsq, 128, w_size * sizeof(real)); // Might perform better than malloc
+  if (gradsq == NULL) {
+    fprintf(stderr, "Error allocating memory for gradsq\n");
+    exit(1);
+  }
+  for ( a = 0; a < w_size; a++) {
+    W[a] = (rand() / (real)RAND_MAX - 0.5) / vector_size;
+    gradsq[a] = 1.0; // So initial value of eta is equal to initial learning rate
+  }
 }
 
 inline real check_nan(real update) {
@@ -101,18 +102,18 @@ void *glove_thread(void *vid) {
     fin = fopen(input_file, "rb");
     fseeko(fin, (num_lines / num_threads * id) * (sizeof(CREC)), SEEK_SET); //Threads spaced roughly equally throughout file
     cost[id] = 0;
-    
+
     real* W_updates1 = (real*)malloc(vector_size * sizeof(real));
     real* W_updates2 = (real*)malloc(vector_size * sizeof(real));
     for (a = 0; a < lines_per_thread[id]; a++) {
         fread(&cr, sizeof(CREC), 1, fin);
         if (feof(fin)) break;
         if (cr.word1 < 1 || cr.word2 < 1) { continue; }
-        
+
         /* Get location of words in W & gradsq */
         l1 = (cr.word1 - 1LL) * (vector_size + 1); // cr word indices start at 1
         l2 = ((cr.word2 - 1LL) + vocab_size) * (vector_size + 1); // shift by vocab_size to get separate vectors for context words
-        
+
         /* Calculate cost, save diff for gradients */
         diff = 0;
         for (b = 0; b < vector_size; b++) diff += W[b + l1] * W[b + l2]; // dot product of word and context word vector
@@ -126,7 +127,7 @@ void *glove_thread(void *vid) {
         }
 
         cost[id] += 0.5 * fdiff * diff; // weighted squared error
-        
+
         /* Adaptive gradient updates */
         fdiff *= eta; // for ease in calculating gradient
         real W_updates1_sum = 0;
@@ -156,11 +157,11 @@ void *glove_thread(void *vid) {
         fdiff *= fdiff;
         gradsq[vector_size + l1] += fdiff;
         gradsq[vector_size + l2] += fdiff;
-        
+
     }
     free(W_updates1);
     free(W_updates2);
-    
+
     fclose(fin);
     pthread_exit(NULL);
 }
@@ -178,7 +179,7 @@ int save_params(int nb_iter) {
     char output_file[MAX_STRING_LENGTH], output_file_gsq[MAX_STRING_LENGTH];
     char *word = malloc(sizeof(char) * MAX_STRING_LENGTH + 1);
     FILE *fid, *fout, *fgs;
-    
+
     if (use_binary > 0) { // Save parameters in binary file
         if (nb_iter <= 0)
             sprintf(output_file,"%s.bin",save_W_file);
@@ -288,7 +289,7 @@ int train_glove() {
     real total_cost = 0;
 
     fprintf(stderr, "TRAINING MODEL\n");
-    
+
     fin = fopen(input_file, "rb");
     if (fin == NULL) {fprintf(stderr,"Unable to open cooccurrence file %s.\n",input_file); return 1;}
     fseeko(fin, 0, SEEK_END);
@@ -305,7 +306,7 @@ int train_glove() {
     if (verbose > 0) fprintf(stderr,"alpha: %lf\n", alpha);
     pthread_t *pt = (pthread_t *)malloc(num_threads * sizeof(pthread_t));
     lines_per_thread = (long long *) malloc(num_threads * sizeof(long long));
-    
+
     time_t rawtime;
     struct tm *info;
     char time_buffer[80];
@@ -362,7 +363,7 @@ int main(int argc, char **argv) {
     save_W_file = malloc(sizeof(char) * MAX_STRING_LENGTH);
     save_gradsq_file = malloc(sizeof(char) * MAX_STRING_LENGTH);
     int result = 0;
-    
+
     if (argc == 1) {
         printf("GloVe: Global Vectors for Word Representation, v0.2\n");
         printf("Author: Jeffrey Pennington (jpennin@stanford.edu)\n\n");
@@ -428,7 +429,7 @@ int main(int argc, char **argv) {
         if ((i = find_arg((char *)"-input-file", argc, argv)) > 0) strcpy(input_file, argv[i + 1]);
         else strcpy(input_file, (char *)"cooccurrence.shuf.bin");
         if ((i = find_arg((char *)"-checkpoint-every", argc, argv)) > 0) checkpoint_every = atoi(argv[i + 1]);
-        
+
         vocab_size = 0;
         fid = fopen(vocab_file, "r");
         if (fid == NULL) {fprintf(stderr, "Unable to open vocab file %s.\n",vocab_file); return 1;}


### PR DESCRIPTION
On line 339 overflow is detected. 
But in the 'symmetric' case, the 'ind' variable gets incremented twice in the loop starting at line 356
and it can therefore still overflow.
Using the condition:
` if (ind >= overflow_length - 2*window_size)`

this is prevented.
