### PR TITLE
Fix superfluous memory usage of initialize_parameters() in glove.c

### DIFF
--- a/src/glove.c
+++ b/src/glove.c
@@ -63,23 +63,23 @@ int scmp( char *s1, char *s2 ) {
 }
 
 void initialize_parameters() {
-	long long a, b;
-	vector_size++; // Temporarily increment to allocate space for bias
-    
-	/* Allocate space for word vectors and context word vectors, and correspodning gradsq */
-	a = posix_memalign((void **)&W, 128, 2 * vocab_size * (vector_size + 1) * sizeof(real)); // Might perform better than malloc
+    long long a, b;
+    vector_size++; // Temporarily increment to allocate space for bias
+
+    /* Allocate space for word vectors and context word vectors, and correspodning gradsq */
+    a = posix_memalign((void **)&W, 128, 2 * vocab_size * vector_size * sizeof(real)); // Might perform better than malloc
     if (W == NULL) {
         fprintf(stderr, "Error allocating memory for W\n");
         exit(1);
     }
-    a = posix_memalign((void **)&gradsq, 128, 2 * vocab_size * (vector_size + 1) * sizeof(real)); // Might perform better than malloc
-	if (gradsq == NULL) {
+    a = posix_memalign((void **)&gradsq, 128, 2 * vocab_size * vector_size * sizeof(real)); // Might perform better than malloc
+    if (gradsq == NULL) {
         fprintf(stderr, "Error allocating memory for gradsq\n");
         exit(1);
     }
-	for (b = 0; b < vector_size; b++) for (a = 0; a < 2 * vocab_size; a++) W[a * vector_size + b] = (rand() / (real)RAND_MAX - 0.5) / vector_size;
-	for (b = 0; b < vector_size; b++) for (a = 0; a < 2 * vocab_size; a++) gradsq[a * vector_size + b] = 1.0; // So initial value of eta is equal to initial learning rate
-	vector_size--;
+    for (b = 0; b < vector_size; b++) for (a = 0; a < 2 * vocab_size; a++) W[a * vector_size + b] = (rand() / (real)RAND_MAX - 0.5) / vector_size;
+    for (b = 0; b < vector_size; b++) for (a = 0; a < 2 * vocab_size; a++) gradsq[a * vector_size + b] = 1.0; // So initial value of eta is equal to initial learning rate
+    vector_size--;
 }
 
 inline real check_nan(real update) {


### PR DESCRIPTION
The current glove.c implementation allocates superfluous memory space for word/context vectors.
Vector size is already incremented for bias in line 67, therefore, we do not need to add 1 afterward.

In addition, the weird indentation is revised, too.