### PR TITLE
Fix misleading comment regarding normalization of vectors

### DIFF
--- a/eval/python/evaluate.py
+++ b/eval/python/evaluate.py
@@ -26,7 +26,7 @@ def main():
             continue
         W[vocab[word], :] = v
 
-    # normalize each word vector to unit variance
+    # normalize each word vector to unit length
     W_norm = np.zeros(W.shape)
     d = (np.sum(W ** 2, 1) ** (0.5))
     W_norm = (W.T / d).T


### PR DESCRIPTION
Small fix in in-line comments:`eval/python/evaluate.py` is normalizing the norm of the word vectors and not their variance as indicated in the in-line comments.