### PR TITLE
Added the option to not weight cooccurrence counts by word distance

### DIFF
--- a/src/cooccur.c
+++ b/src/cooccur.c
@@ -58,7 +58,7 @@ long long overflow_length; // Number of cooccurrence records whose product excee
 int window_size = 15; // default context window size
 int symmetric = 1; // 0: asymmetric, 1: symmetric
 real memory_limit = 3; // soft limit, in gigabytes, used to estimate optimal array sizes
-int distance_weighting = 1;
+int distance_weighting = 1; // Flag to control the distance weighting of cooccurrence counts
 char *vocab_file, *file_head;
 
 /* Efficient string comparison */


### PR DESCRIPTION
I am using GloVe in a context where the order of the tokens and distances between tokens in the context window don't have the same meaning as in most language modeling tasks. Just counting the unweighted cooccurrences leads to more meaningful vectors in some contexts. In the proposed change I am adding an argument in cooccur.c to take a flag to ignore distance between words when counting coocurrences. 

The default behavior remains the same as before, so an explicit flag needs to be passed to switch on the new behavior.