### PR TITLE
fix(shuffle): malloc array_size try-retry 

### DIFF
--- a/src/shuffle.c
+++ b/src/shuffle.c
@@ -188,6 +188,23 @@ int find_arg(char *str, int argc, char **argv) {
     return -1;
 }
 
+int validate_array_size(int requested_array_size, real step_size) {
+    int new_array_size;
+    new_array_size = requested_array_size; // initialize new array_size
+    CREC *array;
+    while(1) {
+        // try to allocate an array, if it works, return the new_array_size
+        array = malloc(sizeof(CREC) * new_array_size); 
+        if (array) {
+            free(array);
+            fprintf(stderr, "Requested array size %d reduced to %d\n", requested_array_size, new_array_size);
+            return new_array_size;
+        }
+        // if array was not allocated, reduce by step size % and try again
+        new_array_size = new_array_size * (1 - step_size);
+    }
+}
+
 int main(int argc, char **argv) {
     int i;
     file_head = malloc(sizeof(char) * MAX_STRING_LENGTH);
@@ -216,6 +233,7 @@ int main(int argc, char **argv) {
     if ((i = find_arg((char *)"-memory", argc, argv)) > 0) memory_limit = atof(argv[i + 1]);
     array_size = (long long) (0.95 * (real)memory_limit * 1073741824/(sizeof(CREC)));
     if ((i = find_arg((char *)"-array-size", argc, argv)) > 0) array_size = atoll(argv[i + 1]);
+    array_size = validate_array_size(array_size, 0.05);
     return shuffle_by_chunks();
 }
 


### PR DESCRIPTION
**Changes:**
* adds `validate_array_size` method
  * reduce by configurable step_size (set to 5%)
  * avoid later segmentation fault

**Purpose:**
During development of a Cython wrapper for this library, I noticed segmentation faults when requesting too much memory via the -memory on the shuffle binary.

After much debugging to find the root cause, [this commit had me implement a "self-healing" array_size](https://github.com/ttymck/crucyble/pull/9/commits/6c42958a570f960fe60347b0f53bae0a62f0a3b5#diff-90cc1329315551383264df8bc53033eeR190). More advanced users may easily overcome this (by adjusting their -memory arg), but I recognize a strong segment of scientific users who may not be able to debug such an error.

I hope this is found useful. Please let me know if this is something you would consider merging, or what changes should be made (I'm rather new to C, so any feedback is appreciated). Cheers!