### PR TITLE
Fix nan during training

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,14 @@
 CC = gcc
 #For older gcc, use -O3 or -O2 instead of -Ofast
 # CFLAGS = -lm -pthread -Ofast -march=native -funroll-loops -Wno-unused-result
-CFLAGS = -lm -pthread -Ofast -march=native -funroll-loops -Wall -Wextra -Wpedantic
+
+# Use -Ofast with caution. It speeds up training, but the checks for NaN will not work
+# (-Ofast turns on --fast-math, which turns on -ffinite-math-only,
+# which assumes everything is NOT NaN or +-Inf, so checks for NaN always return false
+# see https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html)
+# CFLAGS = -lm -pthread -Ofast -march=native -funroll-loops -Wall -Wextra -Wpedantic
+
+CFLAGS = -lm -pthread -O3 -march=native -funroll-loops -Wall -Wextra -Wpedantic
 BUILDDIR := build
 SRCDIR := src
 


### PR DESCRIPTION
This PR fixes two issues with NaNs during training.
First, the checks for NaNs in glove.c did not work with compiler options from the Makefile.
-Ofast disables checks for NaNs and +-Infs. Changed to -O3 by default, so that users at least see the error messages during training.
Second, default learning rate causes on some data exploding gradients, and, as a result, +-Infs and NaNs. People on the internet recommend lowering learning rate in such a case, but this solution is not perfect (users have to get NaNs in their embeddings, then to google for a solution, then train again).
Now, there is a gradient components clipping parameter with a reasonable default which allows training with arbitrary initial learning rates (including default) on arbitrary data out of the box, and no fiddling is required.