### PR TITLE
Raise error if no vocab entries found

### DIFF
--- a/src/glove.c
+++ b/src/glove.c
@@ -447,7 +447,7 @@ int main(int argc, char **argv) {
         if (fid == NULL) {fprintf(stderr, "Unable to open vocab file %s.\n",vocab_file); return 1;}
         while ((i = getc(fid)) != EOF) if (i == '\n') vocab_size++; // Count number of entries in vocab_file
         fclose(fid);
-
+        if (vocab_size == 0) {fprintf(stderr, "Unable to find any vocab entries in vocab file %s.\n", vocab_file); return 1;}
         result = train_glove();
         free(cost);
     }


### PR DESCRIPTION
I passed a directory as the `-vocab-file` argument, which apparently doesn't trigger an error from `fopen`. This led to `vocab_size = 0`, which caused a segfault during execution.

I've raised an error if the vocab size is still 0 after trying to read the vocab file. This seems a bit better than checking for a directory, since we still should raise if an incorrect but existing file path was passed.

The PR should still be useful in addition to #138, as that PR only checks the status from `fread`.