### PR TITLE
fix: fix typo

### DIFF
--- a/src/glove.c
+++ b/src/glove.c
@@ -173,7 +173,7 @@ void *glove_thread(void *vid) {
         pthread_exit(NULL);
     }
     real* W_updates2 = (real*)malloc(vector_size * sizeof(real));
-        if (NULL == W_updates1){
+        if (NULL == W_updates2){
         fclose(fin);
         free(W_updates1);
         pthread_exit(NULL);


### PR DESCRIPTION
I think this is a typo mistake. And it may cause exception if `W_updates2` is NULL