### PR TITLE
Modifications in the eval/python/word_analogies to support Python 3+

### DIFF
--- a/eval/python/word_analogy.py
+++ b/eval/python/word_analogy.py
@@ -1,6 +1,5 @@
 import argparse
 import numpy as np
-import sys
 
 def generate():
     parser = argparse.ArgumentParser()

--- a/eval/python/word_analogy.py
+++ b/eval/python/word_analogy.py
@@ -72,7 +72,7 @@ if __name__ == "__main__":
     N = 100;          # number of closest words that will be shown
     W, vocab, ivocab = generate()
     while True:
-        input_term = raw_input("\nEnter three words (EXIT to break): ")
+        input_term = input("\nEnter three words (EXIT to break): ")
         if input_term == 'EXIT':
             break
         else:

--- a/eval/python/word_analogy.py
+++ b/eval/python/word_analogy.py
@@ -1,5 +1,6 @@
 import argparse
 import numpy as np
+import sys
 
 def generate():
     parser = argparse.ArgumentParser()
@@ -70,8 +71,9 @@ def distance(W, vocab, ivocab, input_term):
 if __name__ == "__main__":
     N = 100;          # number of closest words that will be shown
     W, vocab, ivocab = generate()
+    input_message = "\nEnter three words (EXIT to break): "
     while True:
-        input_term = input("\nEnter three words (EXIT to break): ")
+        input_term = raw_input(input_message) if sys.version_info < (3, 0) else input(input_message)
         if input_term == 'EXIT':
             break
         else:

--- a/eval/python/word_analogy.py
+++ b/eval/python/word_analogy.py
@@ -1,6 +1,5 @@
 import argparse
 import numpy as np
-import sys
 
 def generate():
     parser = argparse.ArgumentParser()
@@ -71,9 +70,8 @@ def distance(W, vocab, ivocab, input_term):
 if __name__ == "__main__":
     N = 100;          # number of closest words that will be shown
     W, vocab, ivocab = generate()
-    input_message = "\nEnter three words (EXIT to break): "
     while True:
-        input_term = raw_input(input_message) if sys.version_info < (3, 0) else input(input_message)
+        input_term = input("\nEnter three words (EXIT to break): ")
         if input_term == 'EXIT':
             break
         else:


### PR DESCRIPTION
Hey! 
I'm I noticed that the `eval/python/word_analogies.py` used `raw_input` to read from stdin. 
In python 3+  `raw_input` was replaced with just `input` (See [PEP 3111](https://www.python.org/dev/peps/pep-3111/) and [What’s New In Python 3.0](https://docs.python.org/3/whatsnew/3.0.html#builtins))
So I made it compatible with python3 and python2. 

Cheers : ) 