### PR TITLE
Step size and gradient clipping for bias terms

### DIFF
--- a/src/glove.c
+++ b/src/glove.c
@@ -224,8 +224,8 @@ void *glove_thread(void *vid) {
         }
 
         // updates for bias terms
-        W[vector_size + l1] -= check_nan(fdiff / sqrt(gradsq[vector_size + l1]));
-        W[vector_size + l2] -= check_nan(fdiff / sqrt(gradsq[vector_size + l2]));
+        W[vector_size + l1] -= check_nan(fmin(fmax(fdiff, -grad_clip_value), grad_clip_value) / sqrt(gradsq[vector_size + l1])) * eta;
+        W[vector_size + l2] -= check_nan(fmin(fmax(fdiff, -grad_clip_value), grad_clip_value) / sqrt(gradsq[vector_size + l2])) * eta;
         fdiff *= fdiff;
         gradsq[vector_size + l1] += fdiff;
         gradsq[vector_size + l2] += fdiff;


### PR DESCRIPTION
I added processing on the updates for the bias terms of the word vectors to mirror the other updates.  Without these, the `eta` and `grad-clip` parameters do not function as described, and the loss function minimized is not quite the one that appears in the original paper.

In personal experiments, this does not seem to affect the final output of the code noticeably in most cases.  It appears to only matter in certain edge cases where the original code fails to converge, such as when the co-occurence matrix contains many entries between 0 and 1.0.