### PR TITLE
Gitignore some files produced by demo.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,11 @@ build/*
 
 # OS X stuff
 ._*
+
+# demo.sh-produced artifacts
+/cooccurrence.bin
+/cooccurrence.shuf.bin
+/text8
+/vectors.bin
+/vectors.txt
+/vocab.txt


### PR DESCRIPTION
They're a bit annoying when working with the repository because they keep appearing in git status output etc.