### PR TITLE
Fixed overflow_threshold overflow when using 256G of memory

### DIFF
--- a/src/cooccur.c
+++ b/src/cooccur.c
@@ -291,7 +291,7 @@ int get_cooccurrence() {
 
     // if symmetric > 0, we can increment ind twice per iteration,
     // meaning up to 2x window_size in one loop
-    int overflow_threshold = symmetric == 0 ? overflow_length - window_size : overflow_length - 2 * window_size;
+    long long const overflow_threshold = symmetric == 0 ? overflow_length - window_size : overflow_length - 2 * window_size;
     
     /* For each token in input stream, calculate a weighted cooccurrence sum within window_size */
     while (1) {


### PR DESCRIPTION
The current implementation using an 'int' runs into an overflow when specifying 256G of memory.
This patch fixed the problem changing the 'int' into a 'long long'.

Fixes: #215 