### PR TITLE
Make check-nan static to resolve undefined reference to check_nan

### DIFF
--- a/src/glove.c
+++ b/src/glove.c
@@ -142,7 +142,7 @@ void initialize_parameters() {
     }
 }
 
-inline real check_nan(real update) {
+static inline real check_nan(real update) {
     if (isnan(update) || isinf(update)) {
         fprintf(stderr,"\ncaught NaN in update");
         return 0.;


### PR DESCRIPTION
Fixes: https://github.com/stanfordnlp/GloVe/issues/172