### PR TITLE
Update evaluate.py

### DIFF
--- a/eval/python/evaluate.py
+++ b/eval/python/evaluate.py
@@ -81,9 +81,9 @@ def evaluate_vectors(W, vocab):
             dist = np.dot(W, pred_vec.T)
 
             for k in range(len(subset)):
-                dist[ind1[subset[k]], k] = -np.Inf
-                dist[ind2[subset[k]], k] = -np.Inf
-                dist[ind3[subset[k]], k] = -np.Inf
+                dist[ind1[subset[k]], k] = -np.inf
+                dist[ind2[subset[k]], k] = -np.inf
+                dist[ind3[subset[k]], k] = -np.inf
 
             # predicted word index
             predictions[subset] = np.argmax(dist, 0).flatten()


### PR DESCRIPTION
`np.Inf` was removed in the NumPy 2.0 release. Use `np.inf` instead.

here is output of master branch run `./demo.sh`:
```bash
$ python eval/python/evaluate.py

Traceback (most recent call last):
  File "/Users/leo9827/Coding/GloVe/eval/python/evaluate.py", line 115, in <module>
    main()
  File "/Users/leo9827/Coding/GloVe/eval/python/evaluate.py", line 33, in main
    evaluate_vectors(W_norm, vocab)
  File "/Users/leo9827/Coding/GloVe/eval/python/evaluate.py", line 84, in evaluate_vectors
    dist[ind1[subset[k]], k] = -np.Inf
  File "/Users/leo9827/.pyenv/versions/3.10.10/lib/python3.10/site-packages/numpy/__init__.py", line 400, in __getattr__
    raise AttributeError(
AttributeError: `np.Inf` was removed in the NumPy 2.0 release. Use `np.inf` instead.
```