### PR TITLE
Fix AttributeError: np.Inf removed in NumPy 2.0. Use np.inf instead.

### DIFF
--- a/eval/python/distance.py
+++ b/eval/python/distance.py
@@ -54,7 +54,7 @@ def distance(W, vocab, ivocab, input_term):
 
     for term in input_term.split(' '):
         index = vocab[term]
-        dist[index] = -np.Inf
+        dist[index] = -np.inf
 
     a = np.argsort(-dist)[:N]
 

--- a/eval/python/word_analogy.py
+++ b/eval/python/word_analogy.py
@@ -57,7 +57,7 @@ def distance(W, vocab, ivocab, input_term):
 
         for term in input_term.split(' '):
             index = vocab[term]
-            dist[index] = -np.Inf
+            dist[index] = -np.inf
 
         a = np.argsort(-dist)[:N]
 


### PR DESCRIPTION
**Issue:** Evaluation scripts crashed with NumPy 2.0 due to the removal of `np.Inf`.
**Fix:** Replaced `np.Inf` with `np.inf` for compatibility.