### PR TITLE
Build: Improve Makefile and fix C compiler warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,8 @@ ifeq ($(APPLE_SILICON),)
 CPU_ARCHITECTURE_FLAGS = -march=native
 endif
 
-CFLAGS = -lm -pthread -O3 $(CPU_ARCHITECTURE_FLAGS) -funroll-loops -Wall -Wextra -Wpedantic
+CFLAGS = -pthread -O3 $(CPU_ARCHITECTURE_FLAGS) -funroll-loops -Wall -Wextra -Wpedantic
+LDLIBS = -lm -pthread
 BUILDDIR := build
 SRCDIR := src
 OBJDIR := $(BUILDDIR)
@@ -33,13 +34,13 @@ all: dir $(OBJ) $(MODULES)
 dir :
 	mkdir -p $(BUILDDIR)
 $(BUILDDIR)/glove : $(OBJDIR)/glove.o $(OBJDIR)/common.o
-	$(CC) $^ -o $@ $(CFLAGS)
+	$(CC) $^ -o $@ $(CFLAGS) $(LDLIBS)
 $(BUILDDIR)/shuffle : $(OBJDIR)/shuffle.o $(OBJDIR)/common.o
-	$(CC) $^ -o $@ $(CFLAGS)
+	$(CC) $^ -o $@ $(CFLAGS) $(LDLIBS)
 $(BUILDDIR)/cooccur : $(OBJDIR)/cooccur.o $(OBJDIR)/common.o
-	$(CC) $^ -o $@ $(CFLAGS)
+	$(CC) $^ -o $@ $(CFLAGS) $(LDLIBS)
 $(BUILDDIR)/vocab_count : $(OBJDIR)/vocab_count.o $(OBJDIR)/common.o
-	$(CC) $^ -o $@ $(CFLAGS)
+	$(CC) $^ -o $@ $(CFLAGS) $(LDLIBS)
 $(OBJDIR)/%.o : $(SRCDIR)/%.c $(HEADERS)
 	$(CC) -c $< -o $@ $(CFLAGS)
 .PHONY: clean

--- a/src/common.c
+++ b/src/common.c
@@ -54,7 +54,7 @@ unsigned int bitwisehash(char *word, int tsize, unsigned int seed) {
 }
 
 /* Create hash table, initialise pointers to NULL */
-HASHREC ** inithashtable() {
+HASHREC ** inithashtable(void) {
     int i;
     HASHREC **ht;
     ht = (HASHREC **) malloc( sizeof(HASHREC *) * TSIZE );

--- a/src/common.h
+++ b/src/common.h
@@ -50,7 +50,7 @@ typedef struct hashrec {
 
 int scmp( char *s1, char *s2 );
 unsigned int bitwisehash(char *word, int tsize, unsigned int seed);
-HASHREC **inithashtable();
+HASHREC **inithashtable(void);
 int get_word(char *word, FILE *fin);
 void free_table(HASHREC **ht);
 int find_arg(char *str, int argc, char **argv);

--- a/src/cooccur.c
+++ b/src/cooccur.c
@@ -229,7 +229,7 @@ void free_resources(HASHREC** vocab_hash, CREC *cr, long long *lookup,
 }
 
 /* Collect word-word cooccurrence counts from input stream */
-int get_cooccurrence() {
+int get_cooccurrence(void) {
     int flag, x, y, fidcounter = 1;
     long long a, j = 0, k, id, counter = 0, ind = 0, vocab_size, w1, w2, *lookup = NULL, *history = NULL;
     char format[20], filename[200], str[MAX_STRING_LENGTH + 1];

--- a/src/glove.c
+++ b/src/glove.c
@@ -89,7 +89,7 @@ int load_init_file(char *file_name, real *array, long long array_size) {
     return 0;
 }
 
-void initialize_parameters() {
+void initialize_parameters(void) {
     // TODO: return an error code when an error occurs, clean up in the calling routine
     if (seed == 0) {
         seed = time(0);
@@ -376,7 +376,7 @@ int save_params(int nb_iter) {
 }
 
 /* Train model */
-int train_glove() {
+int train_glove(void) {
     long long a, file_size;
     int save_params_return_code;
     int b;

--- a/src/shuffle.c
+++ b/src/shuffle.c
@@ -117,7 +117,7 @@ int shuffle_merge(int num) {
 }
 
 /* Shuffle large input stream by splitting into chunks */
-int shuffle_by_chunks() {
+int shuffle_by_chunks(void) {
     if (seed == 0) {
         seed = time(0);
     }

--- a/src/vocab_count.c
+++ b/src/vocab_count.c
@@ -84,7 +84,7 @@ void hashinsert(HASHREC **ht, char *w) {
     return;
 }
 
-int get_counts() {
+int get_counts(void) {
     long long i = 0, j = 0, vocab_size = 12500;
     // char format[20];
     char str[MAX_STRING_LENGTH + 1];


### PR DESCRIPTION
This pull request addresses two issues to improve the C build system:

1. C Code Compiler Warning Fixes

Issue: Compiling the C source produced -Wstrict-prototypes warnings on modern compilers.
Fix: Modernized C function declarations to use (void) instead of () for functions with no arguments, which is the correct syntax.

2. Makefile Build Process Improvement

Issue: The build process produced warnings about unused linker flags (-lm) during the compilation stage.
Fix: Refactored the Makefile to separate compiler flags (CFLAGS) from linker libraries (LDLIBS), applying -lm only during the final linking stage. This cleans up the build output and follows standard Makefile practices.

Supersedes #228