### PR TITLE
Updated vectors documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Make sure you have the following prerequisites installed when running the steps 
 
 The demo.sh script downloads a small corpus, consisting of the first 100M characters of Wikipedia. It collects unigram counts, constructs and shuffles cooccurrence data, and trains a simple version of the GloVe model. It also runs a word analogy evaluation script in python to verify word vector quality. More details about training on your own corpus can be found by reading [demo.sh](https://github.com/stanfordnlp/GloVe/blob/master/demo.sh) or the [src/README.md](https://github.com/stanfordnlp/GloVe/tree/master/src)
 
-### 2024 Vector Documentation 
+## 2024 Vector Documentation 
 The training scripts and data preprocessing pipeline used for training the 2024 vectors can be found in the Training_README.md
 
 Analysis and more documentation for the new vectors can be found at TODO

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 | --- | ------------------------|-------------------------|-------------------------|
 | GloVe Geometry | <img src="https://nlp.stanford.edu/projects/glove/images/man_woman_small.jpg"></img>  | <img src="https://nlp.stanford.edu/projects/glove/images/city_zip_small.jpg"></img> | <img src="https://nlp.stanford.edu/projects/glove/images/comparative_superlative_small.jpg"></img> |
 
-We provide an implementation of the GloVe model for learning word representations, and describe how to download web-dataset vectors or train your own. See the [project page](https://nlp.stanford.edu/projects/glove/) or the [paper](https://nlp.stanford.edu/pubs/glove.pdf) for more information on glove vectors. For documentation and analysis of 2024 vectors, please see the the [report](https://arxiv.org/abs/2507.18103)
+We provide an implementation of the GloVe model for learning word representations, and describe how to download web-dataset vectors or train your own. See the [project page](https://nlp.stanford.edu/projects/glove/) or the [paper](https://nlp.stanford.edu/pubs/glove.pdf) for more information on glove vectors. For documentation and analysis of 2024 vectors, please see the [report](https://arxiv.org/abs/2507.18103)
 
 ## Download pre-trained word vectors \*\***NEW 2024 VECTORS**\*\*
 The links below contain word vectors obtained from the respective corpora. If you want word vectors trained on massive web datasets, you need only download one of these text files! Pre-trained word vectors are made available under the <a href="https://opendatacommons.org/licenses/pddl/">Public Domain Dedication and License</a>.

--- a/README.md
+++ b/README.md
@@ -9,12 +9,17 @@
 | --- | ------------------------|-------------------------|-------------------------|
 | GloVe Geometry | <img src="https://nlp.stanford.edu/projects/glove/images/man_woman_small.jpg"></img>  | <img src="https://nlp.stanford.edu/projects/glove/images/city_zip_small.jpg"></img> | <img src="https://nlp.stanford.edu/projects/glove/images/comparative_superlative_small.jpg"></img> |
 
-We provide an implementation of the GloVe model for learning word representations, and describe how to download web-dataset vectors or train your own. See the [project page](https://nlp.stanford.edu/projects/glove/) or the [paper](https://nlp.stanford.edu/pubs/glove.pdf) for more information on glove vectors.
+We provide an implementation of the GloVe model for learning word representations, and describe how to download web-dataset vectors or train your own. See the [project page](https://nlp.stanford.edu/projects/glove/) or the [paper](https://nlp.stanford.edu/pubs/glove.pdf) for more information on glove vectors. For documentation and analysis of 2024 vectors, please see the TODO LINK
 
-## Download pre-trained word vectors
+## Download pre-trained word vectors \*\***NEW 2024 VECTORS**\*\*
 The links below contain word vectors obtained from the respective corpora. If you want word vectors trained on massive web datasets, you need only download one of these text files! Pre-trained word vectors are made available under the <a href="https://opendatacommons.org/licenses/pddl/">Public Domain Dedication and License</a>.
 <div class="entry">
 <ul style="padding-left:0px; margin-top:0px; margin-bottom:0px">
+  <li> **NEW!!** 2024 Dolma (220B tokens, 1.2M vocab, uncased, 300d vectors, 1.6 GB download): <a href="https://nlp.stanford.edu/data/wordvecs/glove.2024.dolma.300d.zip">glove.2024.dolma.300d.zip</a> </li>
+  <li> **NEW!!** 2024 Wikipedia + Gigaword 5 (11.9B tokens, 1.2M vocab, uncased, 300d vectors, 1.6 GB download): <a href="https://nlp.stanford.edu/data/wordvecs/glove.2024.wikigiga.300d.zip">glove.2024.wikigiga.300d.zip</a> </li>
+  <li> **NEW!!** 2024 Wikipedia + Gigaword 5 (11.9B tokens, 1.2M vocab, uncased, 200d vectors, 1.1 GB download): <a href="https://nlp.stanford.edu/data/wordvecs/glove.2024.wikigiga.200d.zip">glove.2024.wikigiga.200d.zip</a> </li>
+  <li> **NEW!!** 2024 Wikipedia + Gigaword 5 (11.9B tokens, 1.2M vocab, uncased, 100d vectors, 560 MB download): <a href="https://nlp.stanford.edu/data/wordvecs/glove.2024.wikigiga.100d.zip">glove.2024.wikigiga.100d.zip</a> </li>
+   <li> **NEW!!** 2024 Wikipedia + Gigaword 5 (11.9B tokens, 1.2M vocab, uncased, 50d vectors, 290 MB download): <a href="https://nlp.stanford.edu/data/wordvecs/glove.2024.wikigiga.50d.zip">glove.2024.wikigiga.50d.zip</a> </li>
   <li> Common Crawl (42B tokens, 1.9M vocab, uncased, 300d vectors, 1.75 GB download): <a href="https://huggingface.co/stanfordnlp/glove/resolve/main/glove.42B.300d.zip">glove.42B.300d.zip</a> [<a href="https://nlp.stanford.edu/data/wordvecs/glove.42B.300d.zip">mirror</a>] </li>
   <li> Common Crawl (840B tokens, 2.2M vocab, cased, 300d vectors, 2.03 GB download): <a href="https://huggingface.co/stanfordnlp/glove/resolve/main/glove.840B.300d.zip">glove.840B.300d.zip</a> [<a href="https://nlp.stanford.edu/data/wordvecs/glove.840B.300d.zip">mirror</a>] </li>
   <li> Wikipedia 2014 + Gigaword 5 (6B tokens, 400K vocab, uncased, 300d vectors, 822 MB download): <a href="https://huggingface.co/stanfordnlp/glove/resolve/main/glove.6B.zip">glove.6B.zip</a> [<a href="https://nlp.stanford.edu/data/wordvecs/glove.6B.zip">mirror</a>] </li>

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 | --- | ------------------------|-------------------------|-------------------------|
 | GloVe Geometry | <img src="https://nlp.stanford.edu/projects/glove/images/man_woman_small.jpg"></img>  | <img src="https://nlp.stanford.edu/projects/glove/images/city_zip_small.jpg"></img> | <img src="https://nlp.stanford.edu/projects/glove/images/comparative_superlative_small.jpg"></img> |
 
-We provide an implementation of the GloVe model for learning word representations, and describe how to download web-dataset vectors or train your own. See the [project page](https://nlp.stanford.edu/projects/glove/) or the [paper](https://nlp.stanford.edu/pubs/glove.pdf) for more information on glove vectors. For documentation and analysis of 2024 vectors, please see the TODO LINK
+We provide an implementation of the GloVe model for learning word representations, and describe how to download web-dataset vectors or train your own. See the [project page](https://nlp.stanford.edu/projects/glove/) or the [paper](https://nlp.stanford.edu/pubs/glove.pdf) for more information on glove vectors. For documentation and analysis of 2024 vectors, please see the the [report](https://arxiv.org/abs/2507.18103)
 
 ## Download pre-trained word vectors \*\***NEW 2024 VECTORS**\*\*
 The links below contain word vectors obtained from the respective corpora. If you want word vectors trained on massive web datasets, you need only download one of these text files! Pre-trained word vectors are made available under the <a href="https://opendatacommons.org/licenses/pddl/">Public Domain Dedication and License</a>.
@@ -48,7 +48,7 @@ The demo.sh script downloads a small corpus, consisting of the first 100M charac
 ## 2024 Vector Documentation 
 The training scripts and data preprocessing pipeline used for training the 2024 vectors can be found in the Training_README.md
 
-Analysis and more documentation for the new vectors can be found at TODO
+Analysis and more documentation for the new vectors can be found in this [report](https://arxiv.org/abs/2507.18103)
 
 ### License
 All work contained in this package is licensed under the Apache License, Version 2.0. See the include LICENSE file.

--- a/README.md
+++ b/README.md
@@ -40,5 +40,10 @@ Make sure you have the following prerequisites installed when running the steps 
 
 The demo.sh script downloads a small corpus, consisting of the first 100M characters of Wikipedia. It collects unigram counts, constructs and shuffles cooccurrence data, and trains a simple version of the GloVe model. It also runs a word analogy evaluation script in python to verify word vector quality. More details about training on your own corpus can be found by reading [demo.sh](https://github.com/stanfordnlp/GloVe/blob/master/demo.sh) or the [src/README.md](https://github.com/stanfordnlp/GloVe/tree/master/src)
 
+### 2024 Vector Documentation 
+The training scripts and data preprocessing pipeline used for training the 2024 vectors can be found in the Training_README.md
+
+Analysis and more documentation for the new vectors can be found at TODO
+
 ### License
 All work contained in this package is licensed under the Apache License, Version 2.0. See the include LICENSE file.

--- a/Training_README.md
+++ b/Training_README.md
@@ -1,0 +1,46 @@
+### Overview
+
+Five new vectors were trained. Four of these vectors were trained on Gigaword and updated Wikipedia corpora and the fifth was traind on [Dolma](https://allenai.github.io/dolma/). This document includes the scripts used to train these five vectors. 
+
+### Data Download and Preprocessing 
+
+The Wikipedia portion of the corpora was downloaded from the [7/22/2024 dump](https://dumps.wikimedia.org/enwiki/20240720/enwiki-20240720-pages-meta-current.xml.bz2). The fifth edition of [Gigaword](https://catalog.ldc.upenn.edu/LDC2011T07) was used. TODO DOLMA WHERE TO GET 
+
+For tokenization, version 4.4.1 of Stanford's CoreNLP tokenizer was used. We used the script 
+    $java edu.stanford.nlp.process.PTBTokenizer -preserveLines -lowerCase -options 'untokenizable=allKeep'
+
+When combining the Wikipedia and Gigaword data, Gigaword was added twice to balance the increase in Wikipedia data from the previous training corpus.
+
+### Vector Training 
+
+Here is the bash script used for training the vectors
+$  CORPUS=<wikigiga, dolma>
+$  VOCAB_FILE=<wikigiga_vocab.txt, dolma_vocab.txt>
+$  COOCCURRENCE_FILE=vocab.txt
+$  COOCCURRENCE_SHUF_FILE=cooccurrence.shuf.bin
+$  BUILDDIR=build
+$  SAVE_FILE=vectors.txt
+$  VERBOSE=2
+$  MEMORY=4.0
+$  VOCAB_MIN_COUNT=20
+$  VECTOR_SIZE=<50, 100, 200, 300>
+$  MAX_ITER=<50,100>
+$  WINDOW_SIZE=10
+$  BINARY=2
+$  NUM_THREADS=8
+$  X_MAX=10
+$  SEED=<123, 2024>
+$  ALPHA=0.75
+$  ETA=<0.05, 0.075>
+$  $BUILDDIR/vocab_count  -min-count $VOCAB_MIN_COUNT -verbose $VERBOSE < $CORPUS > $VOCAB_FILE
+$  $BUILDDIR/cooccur -memory $MEMORY -overflow-file $OVERFLOW_FILE -vocab-file $VOCAB_FILE -verbose $VERBOSE -window-size $WINDOW_SIZE < $CORPUS > $COOCCURRENCE_FILE
+$  $BUILDDIR/shuffle -memory $MEMORY -seed $SEED -verbose $VERBOSE < $COOCCURRENCE_FILE > $COOCCURRENCE_SHUF_FILE
+
+## Vocabulary:
+For dolma, a maximum vocabulary of 1.2M was used by passing the -max-vocab flag 
+
+## Cooccurrence building and shuffling :
+
+
+
+

--- a/Training_README.md
+++ b/Training_README.md
@@ -4,9 +4,13 @@ Five new vectors were trained. Four of these vectors were trained on Gigaword an
 
 ## Data Download and Preprocessing 
 
-The Wikipedia portion of the corpora was downloaded from the [7/22/2024 dump](https://dumps.wikimedia.org/enwiki/20240720/enwiki-20240720-pages-meta-current.xml.bz2). The fifth edition of [Gigaword](https://catalog.ldc.upenn.edu/LDC2011T07) was used. Dolma v1.6 was used and 5% of Common Crawl, 40% of C4, 100% of Reddit, and 100% of Project Gutenberg were used. 
+The Wikipedia portion of the corpora was downloaded from the [7/22/2024 dump](https://dumps.wikimedia.org/enwiki/20240720/enwiki-20240720-pages-meta-current.xml.bz2). The text was then extracted using [Wikiextractor](https://github.com/attardi/wikiextractor) with the command 
+``` 
+python -m wikiextractor.WikiExtractor enwiki-20220620-pages-meta-current.xml --no-templates --output output_dir/
+```
+The fifth edition of [Gigaword](https://catalog.ldc.upenn.edu/LDC2011T07) was used. Dolma v1.6 was used and 5% of Common Crawl, 40% of C4, 100% of Reddit, and 100% of Project Gutenberg were used. 
 
-For tokenization, version 4.4.1 of Stanford's CoreNLP tokenizer was used. We used the script 
+For tokenization, version 4.4.1 of Stanford's Stanza tokenizer was used. We used the script 
 
 ```java edu.stanford.nlp.process.PTBTokenizer -preserveLines -lowerCase -options 'untokenizable=allKeep'```
 

--- a/Training_README.md
+++ b/Training_README.md
@@ -1,46 +1,53 @@
-#Overview
+## Overview
 
-Five new vectors were trained. Four of these vectors were trained on Gigaword and updated Wikipedia corpora and the fifth was traind on [Dolma](https://allenai.github.io/dolma/). This document includes the scripts used to train these five vectors. 
+Five new vectors were trained. Four of these vectors were trained on Gigaword and updated Wikipedia corpus and the fifth was trained on [Dolma](https://allenai.github.io/dolma/). This document includes the scripts used to train these five vectors. 
 
 ## Data Download and Preprocessing 
 
-The Wikipedia portion of the corpora was downloaded from the [7/22/2024 dump](https://dumps.wikimedia.org/enwiki/20240720/enwiki-20240720-pages-meta-current.xml.bz2). The fifth edition of [Gigaword](https://catalog.ldc.upenn.edu/LDC2011T07) was used. TODO DOLMA WHERE TO GET 
+The Wikipedia portion of the corpora was downloaded from the [7/22/2024 dump](https://dumps.wikimedia.org/enwiki/20240720/enwiki-20240720-pages-meta-current.xml.bz2). The fifth edition of [Gigaword](https://catalog.ldc.upenn.edu/LDC2011T07) was used. Dolma v1.6 was used and 5% of Common Crawl, 40% of C4, 100% of Reddit, and 100% of Project Gutenberg were used. 
 
 For tokenization, version 4.4.1 of Stanford's CoreNLP tokenizer was used. We used the script 
-    $java edu.stanford.nlp.process.PTBTokenizer -preserveLines -lowerCase -options 'untokenizable=allKeep'
+
+```java edu.stanford.nlp.process.PTBTokenizer -preserveLines -lowerCase -options 'untokenizable=allKeep'```
 
 When combining the Wikipedia and Gigaword data, Gigaword was added twice to balance the increase in Wikipedia data from the previous training corpus.
 
 ## Vector Training 
 
-Here is the bash script used for training the vectors
-$  CORPUS=<wikigiga, dolma>
-$  VOCAB_FILE=<wikigiga_vocab.txt, dolma_vocab.txt>
-$  COOCCURRENCE_FILE=vocab.txt
-$  COOCCURRENCE_SHUF_FILE=cooccurrence.shuf.bin
-$  BUILDDIR=build
-$  SAVE_FILE=vectors.txt
-$  VERBOSE=2
-$  MEMORY=4.0
-$  VOCAB_MIN_COUNT=20
-$  VECTOR_SIZE=<50, 100, 200, 300>
-$  MAX_ITER=<50,100>
-$  WINDOW_SIZE=10
-$  BINARY=2
-$  NUM_THREADS=8
-$  X_MAX=10
-$  SEED=<123, 2024>
-$  ALPHA=0.75
-$  ETA=<0.05, 0.075>
-$  $BUILDDIR/vocab_count  -min-count $VOCAB_MIN_COUNT -verbose $VERBOSE < $CORPUS > $VOCAB_FILE
-$  $BUILDDIR/cooccur -memory $MEMORY -overflow-file $OVERFLOW_FILE -vocab-file $VOCAB_FILE -verbose $VERBOSE -window-size $WINDOW_SIZE < $CORPUS > $COOCCURRENCE_FILE
-$  $BUILDDIR/shuffle -memory $MEMORY -seed $SEED -verbose $VERBOSE < $COOCCURRENCE_FILE > $COOCCURRENCE_SHUF_FILE
+Here is the bash script used for training the vectors Wiki Giga vectors 50/100/200/300 dimension and Dolma 300 dimension
+``` 
+CORPUS=<wikigiga, dolma>
+VOCAB_FILE=vocab.txt
+COOCCURRENCE_FILE=cooccurrence.bin
+COOCCURRENCE_SHUF_FILE=cooccurrence.shuf.bin
+BUILDDIR=build
+SAVE_FILE=vectors.txt
+OVERFLOW_FILE=overflow
+VERBOSE=2
+MEMORY=4.0
+VOCAB_MIN_COUNT=20
+VECTOR_SIZE=<50, 100, 200, 300>
+MAX_ITER=<50,100>
+WINDOW_SIZE=10
+BINARY=2
+NUM_THREADS=8
+X_MAX=10
+SEED=<123, 2024>
+ALPHA=0.75
+ETA=<0.05, 0.075>
+$BUILDDIR/vocab_count  -min-count $VOCAB_MIN_COUNT -verbose $VERBOSE < $CORPUS > $VOCAB_FILE
+$BUILDDIR/cooccur -memory $MEMORY -overflow-file $OVERFLOW_FILE -vocab-file $VOCAB_FILE -verbose $VERBOSE -window-size $WINDOW_SIZE < $CORPUS > $COOCCURRENCE_FILE
+$BUILDDIR/shuffle -memory $MEMORY -seed $SEED -verbose $VERBOSE < $COOCCURRENCE_FILE > $COOCCURRENCE_SHUF_FILE
+$BUILDDIR/glove -eta $ETA -alpha $ALPHA -save-file $SAVE_FILE -threads $NUM_THREADS -input-file
+    $COOCCURRENCE_SHUF_FILE -x-max $X_MAX -iter $MAX_ITER -vector-size $VECTOR_SIZE -binary $BINARY 
+    -vocab-file $VOCAB_FILE -verbose $VERBOSE -seed $SEED -checkpoint-every 10
 
+```
 ### Vocabulary:
 For dolma, a maximum vocabulary of 1.2M was used by passing the -max-vocab flag 
 
-### Cooccurrence building and shuffling :
-
+### Vector Training:
+For Wiki Giga 50 dimension, random seed 123 and learning rate of 0.075 was used. For all other vectors, random seed 2024 and learning rate of 0.05 was used
 
 
 

--- a/Training_README.md
+++ b/Training_README.md
@@ -1,8 +1,8 @@
-### Overview
+#Overview
 
 Five new vectors were trained. Four of these vectors were trained on Gigaword and updated Wikipedia corpora and the fifth was traind on [Dolma](https://allenai.github.io/dolma/). This document includes the scripts used to train these five vectors. 
 
-### Data Download and Preprocessing 
+## Data Download and Preprocessing 
 
 The Wikipedia portion of the corpora was downloaded from the [7/22/2024 dump](https://dumps.wikimedia.org/enwiki/20240720/enwiki-20240720-pages-meta-current.xml.bz2). The fifth edition of [Gigaword](https://catalog.ldc.upenn.edu/LDC2011T07) was used. TODO DOLMA WHERE TO GET 
 
@@ -11,7 +11,7 @@ For tokenization, version 4.4.1 of Stanford's CoreNLP tokenizer was used. We use
 
 When combining the Wikipedia and Gigaword data, Gigaword was added twice to balance the increase in Wikipedia data from the previous training corpus.
 
-### Vector Training 
+## Vector Training 
 
 Here is the bash script used for training the vectors
 $  CORPUS=<wikigiga, dolma>
@@ -36,10 +36,10 @@ $  $BUILDDIR/vocab_count  -min-count $VOCAB_MIN_COUNT -verbose $VERBOSE < $CORPU
 $  $BUILDDIR/cooccur -memory $MEMORY -overflow-file $OVERFLOW_FILE -vocab-file $VOCAB_FILE -verbose $VERBOSE -window-size $WINDOW_SIZE < $CORPUS > $COOCCURRENCE_FILE
 $  $BUILDDIR/shuffle -memory $MEMORY -seed $SEED -verbose $VERBOSE < $COOCCURRENCE_FILE > $COOCCURRENCE_SHUF_FILE
 
-## Vocabulary:
+### Vocabulary:
 For dolma, a maximum vocabulary of 1.2M was used by passing the -max-vocab flag 
 
-## Cooccurrence building and shuffling :
+### Cooccurrence building and shuffling :
 
 
 


### PR DESCRIPTION
This PR holds updated documentation for the 2024 GloVe vectors. The documentation updated in the README.md includes links to the new vectors along with a link to the report. Further in Training_README.md, there is detailed documentation on the hyperparameters used to train the new embeddings. 